### PR TITLE
Contain fix for new AGP version where namespace required in build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,8 +22,8 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'fr.g123k.deviceapps'
     compileSdkVersion 30
-
     defaultConfig {
         minSdkVersion 16
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,9 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    namespace 'fr.g123k.deviceapps'
+    if (project.android.hasProperty("namespace")) {
+        namespace 'fr.g123k.deviceapps'
+    }
     compileSdkVersion 30
     defaultConfig {
         minSdkVersion 16

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_apps
 description: List applications installed on an Android device (iOS is not supported). You can also monitor application changes (updates, uninstallation…)
-version: 2.2.0
+version: 3.0.0
 homepage: https://github.com/g123k/flutter_plugin_device_apps
 
 environment:


### PR DESCRIPTION
In newer versions of AGP, the declaration of namespace/package was moved from AndroidManifest and to build script.